### PR TITLE
マイページ編集画面でプロフィール画像のプレビュー表示実装

### DIFF
--- a/app/assets/javascripts/user_edit.js
+++ b/app/assets/javascripts/user_edit.js
@@ -1,0 +1,29 @@
+$(document).on('turbolinks:load', function(){
+  $('#user_image').on('change', function(e) {
+    var file = e.target.files[0],
+    reader = new FileReader(),
+    $preview = $(".imageFieldLabel");
+    t = this;
+    
+    // 画像ファイル以外の場合は何もしない
+    if(file.type.indexOf("image") < 0){
+      return false;
+    }
+    
+    // ファイル読み込みが完了した際のイベント登録
+    reader.onload = (function(file) {
+
+      return function(e) {
+        //既存のプレビューを削除
+        $preview.empty();
+        // .prevewの領域の中にロードした画像を表示するimageタグを追加
+        $preview.append($('<img>').attr({
+                  src: e.target.result,
+                  class: "preview",
+              }));
+      };
+    })(file);
+
+    reader.readAsDataURL(file);
+  });
+});

--- a/app/assets/stylesheets/_profiles.scss
+++ b/app/assets/stylesheets/_profiles.scss
@@ -118,7 +118,7 @@
             width: 135px;
             border-radius: 50%;
             object-fit: cover;
-            margin: 15px 0 0;
+            margin: 10px 0 0;
           }
           &__name{
             display: block;

--- a/app/assets/stylesheets/modules/user.scss
+++ b/app/assets/stylesheets/modules/user.scss
@@ -105,11 +105,13 @@
       i {
         font-size: 11px;
       }
+      .preview,
       .imageFieldLabel{
         display: block;
         background-image: image-url("default.png");
         background-size: cover;
         background-position: center;
+        object-fit: cover;
         height: 120px;
         width: 120px;
         border-radius: 50%;
@@ -117,7 +119,7 @@
         margin: 0 auto;
       }
       .imageFieldLabel:hover{
-        box-shadow: 2px 2px 6px 0 #000000;
+        box-shadow: 0 1px 4px 0 #000000;
         transition-duration: 0.5s;
       }
     }


### PR DESCRIPTION
# whay
jsファイルを追加

# why
- editページでマイページに設定する画僧をプレビュー表示可能にする
- ユーザーにプロフィール画像のイメージ、選択できたかどうかを確認可能にする為