### PR TITLE
ユーザー新規登録時の必須項目のビュー調整

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ group :development, :test do
   gem 'capistrano3-unicorn'
   gem 'rspec-rails'
   gem 'factory_bot_rails'
+  gem 'faker', "~> 2.8"
 end
 
 group :development do
@@ -64,7 +65,6 @@ group :test do
   # Easy installation and use of chromedriver to run system tests with Chrome
   # gem 'chromedriver-helper'
   gem 'webdrivers'
-  gem 'faker', "~> 2.8"
 end
 
 group :production do

--- a/app/assets/stylesheets/modules/user.scss
+++ b/app/assets/stylesheets/modules/user.scss
@@ -231,3 +231,18 @@
 .imageField{
   display: none;
 } 
+
+.required{
+  display: inline-block;
+  background: red;
+  border-radius: 6px;
+  padding: 0 5px;
+}
+
+.any{
+  display: inline-block;
+  background: #494949;
+  color: $white;
+  border-radius: 6px;
+  padding: 0 5px;
+}

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -15,52 +15,72 @@
         .field
           .field-label
             = f.label :name
+            .required
+              必須
           .field-input
             = f.text_field :name, placeholder: "please enter", autofocus: true
         .field
           .field-label
             = f.label :email
+            .required
+              必須
           .field-input
             = f.email_field :email, placeholder: "please enter"
         .field
           .field-label
             = f.label :age
+            .any
+              任意
           .field-input
             = f.text_field :age, placeholder: "please enter"
         .field
           .field-label
             = f.label :occupation
+            .any
+              任意
           .field-input
             = f.text_field :occupation, placeholder: "please enter"
         .field
           .field-label
             = f.label :experience
+            .any
+              任意
           .field-input
             = f.text_field :experience, placeholder: "please enter"
         .field
           .field-label
             = f.label :sns, "SNS"
+            .any
+              任意
           .field-input
             = f.text_field :sns, placeholder: "please enter"
         .field
           .field-label
             = f.label :programming_lang, "Programmnig Lang"
+            .any
+              任意
           .field-input
             = f.text_area :programming_lang, rows: 10, cols: 51, placeholder: "please enter\nマークダウン記法が使えます"
         .field
           .field-label
             = f.label :pr, "PR"
+            .any
+              任意
           .field-input
             = f.text_area :pr, rows: 10, cols: 51, placeholder: "please enter\nマークダウン記法が使えます"
         .field
           .field-label
             = f.label :password
             %i (英数字8文字以上)
+            .required
+              必須
           .field-input
             = f.password_field :password, placeholder: "please enter", autocomplete: "off"
         .field
           .field-label
             = f.label :password_confirmation
+            .required
+              必須
           .field-input
             = f.password_field :password_confirmation, placeholder: "please enter", autocomplete: "off"
         .actions


### PR DESCRIPTION
# what
- ユーザー新規登録ページに必須項目と任意項目の記述を追加
- gem fakerの記述位置を修正

# why
- ユーザビリティを考え必要最低限の登録情報でユーザーを作成できる様に
- gem fakerがdevelopmentのみの記述だとローカルサーバーが起動できないのでtestにも追加